### PR TITLE
Enable testing on OSX, with and without homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env: _R_CHECK_FORCE_SUGGESTS_=FALSE
 matrix:
   include:
     - os: linux
-      dist: trusty
       env: R_CODECOV=true
     - os: osx
       osx_image: xcode8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: R
 sudo: false
 cache: packages
+env: _R_CHECK_FORCE_SUGGESTS_=FALSE
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,20 @@ language: R
 sudo: false
 cache: packages
 
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      env: R_CODECOV=true
+    - os: osx
+      osx_image: xcode8.3
+      brew_packages: hiredis
+      latex: false
+    - os: osx
+      osx_image: xcode7.3
+      disable_homebrew: true
+      latex: false
+
 addons:
   apt:
     packages:
@@ -18,5 +32,6 @@ notifications:
 
 r_packages:
   - covr
+
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/configure
+++ b/configure
@@ -10,9 +10,9 @@ PKG_CONFIG_NAME="hiredis"
 PKG_DEB_NAME="libhiredis-dev"
 PKG_RPM_NAME="hiredis-devel"
 PKG_BREW_NAME="hiredis"
-PKG_TEST_HEADER="<hiredis/hiredis.h>"
+PKG_TEST_HEADER="<hiredis.h>"
+PKG_CFLAGS="-I/usr/include/hiredis"
 PKG_LIBS="-lhiredis"
-PKG_CFLAGS=""
 
 # Use pkg-config if available
 if [ $(command -v pkg-config) ]; then

--- a/configure
+++ b/configure
@@ -1,15 +1,12 @@
 #!/bin/bash
-# Anticonf (tm) script by Jeroen Ooms (2016)
+# Anticonf (tm) script by Jeroen Ooms (2017)
 # This script will query 'pkg-config' for the required cflags and ldflags.
 # If pkg-config is unavailable or does not find the library, try setting
 # INCLUDE_DIR and LIB_DIR manually via e.g:
 # R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
 
-# Modified by RGF to also try PREFIX=/usr/local because that's where
-# hiredis installs on a Mac.
-
 # Library settings
-PKG_CONFIG_NAME="libhiredis"
+PKG_CONFIG_NAME="hiredis"
 PKG_DEB_NAME="libhiredis-dev"
 PKG_RPM_NAME="hiredis-devel"
 PKG_BREW_NAME="hiredis"
@@ -33,32 +30,14 @@ elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
   PKG_CFLAGS=${PKGCONFIG_CFLAGS}
   PKG_LIBS=${PKGCONFIG_LIBS}
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  if [ -f /usr/local/include/hiredis/hiredis.h ]; then
-    PKG_CFLAGS=-I/usr/local/include
-    PKG_LIBS="-L/usr/local/lib $PKG_LIBS"
-    if [ ! $(echo "$DYLD_LIBRARY_PATH" | grep "/usr/local/lib") ]; then
-      echo "------------------------- ANTICONF WARNING -------------------------"
-      echo "DYLD_LIBRARY_PATH does include /usr/local/lib but hiredis found there"
-      echo "The package load will fail."
-      echo "You need to set DYLD_LIBRARY_PATH=/usr/local/lib (not set by default on Mac)"
-      echo "--------------------------------------------------------------------"
-    fi
+  if [ $(command -v brew) ]; then
+    BREWDIR=$(brew --prefix)
   else
-    if [ $(command -v brew) ]; then
-      BREWDIR=$(brew --prefix)
-    else
-      echo "Auto-brewing $PKG_BREW_NAME..."
-      BREWDIR="/tmp/homebrew"
-      rm -Rf $BREWDIR
-      mkdir -p $BREWDIR
-      curl -fsSL https://github.com/Homebrew/homebrew/tarball/master | tar xz --strip 1 -C $BREWDIR
-      HOMEBREW_CACHE="/tmp" $BREWDIR/bin/brew install $PKG_BREW_NAME 2>&1 | sed 's/Warning/Note/g'
-      rm -f $BREWDIR/Cellar/$PKG_BREW_NAME/*/lib/*.dylib
-      rm -f $BREWDIR/opt/$PKG_BREW_NAME/lib/*.dylib
-    fi
-    PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"
-    PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
+    curl -sfL "https://jeroen.github.io/autobrew/$PKG_BREW_NAME" > autobrew
+    source autobrew
   fi
+  PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include/hiredis -D_FILE_OFFSET_BITS=64"
+  PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
 fi
 
 # For debugging

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 # -*- makefile -*-
-PKG_CPPFLAGS=-I../windows/hiredis-0.9.2/include -DSTRICT_R_HEADERS
+PKG_CPPFLAGS=-I../windows/hiredis-0.9.2/include/hiredis -DSTRICT_R_HEADERS
 PKG_LIBS=-L../windows/hiredis-0.9.2/lib${R_ARCH} -lhiredis -lws2_32
 
 all: clean winlibs

--- a/src/connection.h
+++ b/src/connection.h
@@ -1,6 +1,6 @@
 #include <R.h>
 #include <Rinternals.h>
-#include <hiredis/hiredis.h>
+#include <hiredis.h>
 #include <stdbool.h>
 
 SEXP redux_redis_connect(SEXP host, SEXP port);

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -1,6 +1,6 @@
 #include <R.h>
 #include <Rinternals.h>
-#include <hiredis/hiredis.h>
+#include <hiredis.h>
 #include <stdbool.h>
 
 /* whole reply */


### PR DESCRIPTION
Two new entries for testing on MAC. The `xcode-8.3` tests dynamic linking on the most recent version of OSX. The `xcode-7.3` with `disable_hombrew` simulates static linking on the CRAN builder.