### PR TITLE
support redis 5.0 commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ extra/redis-doc
 .valgrind_ignore
 src/redux.so.dSYM
 autobrew
+*.so
+*.o

--- a/extra/generate_fun.R
+++ b/extra/generate_fun.R
@@ -68,13 +68,19 @@ hiredis_cmd <- function(x, standalone = FALSE) {
   is_grouped <- lengths(args$name) > 1L
 
   if (any(is_command)) {
+    if(is.null(args$name)) args$name = args$command
+    
     j <- is_command & !(is_grouped & is_multiple)
     args$name_orig <- args$name
     args$command_length <- viapply(args$name, length)
     args$name[j] <- args$command[j]
     is_grouped <- viapply(args$name, length) > 1L
   }
-
+  
+  if (any(duplicated(args$name))) {
+    args$name = make.unique(args$name, sep = "_")
+  }
+  
   if (any(args$variadic)) {
     args$command_length[args$variadic] <- 2
   }


### PR DESCRIPTION
- fix problems with json parsing for API generation
- regenerate API to support redis 5.0 (redis doc commit db399bb9f3871a749bc14cc9d60761a7bfd73cf8)
- add .o. .so to gitignore
