### PR TITLE
Windows: update to hiredis 1.0.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,7 @@ install:
 
 # Adapt as necessary starting from here
 before_build:
-  - choco install redis-64
-  - redis-server --service-install
-  - redis-server --service-start
+  - choco install memurai-developer
 
 build_script:
   - travis-tool.sh install_deps

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,6 @@
 # -*- makefile -*-
-PKG_CPPFLAGS=-I../windows/hiredis-0.9.2/include/hiredis -DSTRICT_R_HEADERS
-PKG_LIBS=-L../windows/hiredis-0.9.2/lib${R_ARCH} -lhiredis -lws2_32
+PKG_CPPFLAGS=-I../windows/hiredis-1.0.0/include/hiredis -DSTRICT_R_HEADERS
+PKG_LIBS=-L../windows/hiredis-1.0.0/lib${R_ARCH} -lhiredis -lws2_32
 
 all: clean winlibs
 

--- a/src/registration.c
+++ b/src/registration.c
@@ -1,3 +1,6 @@
+#ifdef _WIN32
+#include <winsock2.h>
+#endif
 #include "connection.h"
 #include "conversions.h"
 #include "subscribe.h"

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,6 +1,6 @@
-if (!file.exists("../windows/hiredis-0.9.2/include/hiredis/hiredis.h")) {
+if (!file.exists("../windows/hiredis-1.0.0/include/hiredis/hiredis.h")) {
   if (getRversion() < "3.3.0") setInternet2()
-  download.file("https://github.com/rwinlib/hiredis/archive/v0.9.2.zip", "lib.zip", quiet = TRUE)
+  download.file("https://github.com/rwinlib/hiredis/archive/v1.0.0.zip", "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
This is a prerequisite for a user that is working on SSL support.

Also, the chocolately `redis-64` package seems to be deprecated, and is now a virtual package that installs another one. From the description:

> The MS Open Tech Redis on Windows was frozen at version 3.x when it was archived few years ago. Since that time there were a few new major releases of Redis on Linux. Reading the release notes for Redis 4.x and Redis 5.x, one can see that there are several security vulnerabilities that were fixed since.
The current package might pose risk to systems and it is better to retire it. As an alternative to the old package we recommend using Memurai which is on par with Redis 5.x and has the known security vulnerabilities addressed.