### PR TITLE
Addresses #27: Adds support for making SSL connections to redis via hiredis 1.0.0+

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -65,7 +65,7 @@ redis_config <- function(..., config = list(...)) {
   ##   2 arg and char/int, unnamed (assume host/port?)
   defaults <- list(
                 url = Sys_getenv("REDIS_URL", NULL),
-                scheme = "redis",
+                scheme = Sys_getenv("REDIS_CONNECTION_SCHEME", "redis"),
                 host = Sys_getenv("REDIS_HOST", "127.0.0.1"),
                 port = as.integer(Sys_getenv("REDIS_PORT", 6379L)),
                 path = NULL,

--- a/R/config.R
+++ b/R/config.R
@@ -70,7 +70,10 @@ redis_config <- function(..., config = list(...)) {
                 port = as.integer(Sys_getenv("REDIS_PORT", 6379L)),
                 path = NULL,
                 password = NULL,
-                db = NULL)
+                db = NULL,
+				CApath = Sys_getenv("REDIS_SSL_CA_PATH", NULL),
+				certPath = Sys_getenv("REDIS_SSL_CERT_PATH", NULL),
+				keyPath = Sys_getenv("REDIS_SSL_KEY_PATH", NULL))
   dots <- list(...)
   if (length(dots) > 0L && !identical(dots, config)) {
     warning("Ignoring dots in favour of config")

--- a/R/redis.R
+++ b/R/redis.R
@@ -5,6 +5,9 @@
 redis_connect <- function(config) {
   if (config$scheme == "redis") {
     ptr <- redis_connect_tcp(config$host, config$port)
+  } else if (config$scheme == "rediss")  {
+	ptr <- redis_connect_tcp_ssl(config$host, config$port, config$CApath,
+			                     config$certPath, config$keyPath)
   } else {
     ptr <- redis_connect_unix(config$path)
   }
@@ -19,6 +22,11 @@ redis_connect <- function(config) {
 
 redis_connect_tcp <- function(host, port) {
   .Call(Credux_redis_connect, host, as.integer(port))
+}
+
+redis_connect_tcp_ssl <- function(host, port, CApath, certPath, keyPath) {
+	.Call(Credux_redis_connect_ssl, host, as.integer(port), 
+			CApath, certPath, keyPath)
 }
 
 redis_connect_unix <- function(path) {

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,6 @@
 # -*- makefile -*-
-PKG_CPPFLAGS=-I../windows/hiredis-0.9.2/include/hiredis -DSTRICT_R_HEADERS
-PKG_LIBS=-L../windows/hiredis-0.9.2/lib${R_ARCH} -lhiredis -lws2_32
+PKG_CPPFLAGS=-I../windows/hiredis-1.0.0/include/hiredis -DSTRICT_R_HEADERS
+PKG_LIBS=-L../windows/hiredis-1.0.0/lib${R_ARCH} -lhiredis -lhiredis_ssl -lssl -lcrypto -lcrypt32 -lws2_32
 
 all: clean winlibs
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -27,24 +27,24 @@ SEXP redux_redis_connect_ssl(SEXP host, SEXP port, SEXP CApath,
 
   // hiredis SSL connection context and error var
   redisSSLContext *redis_ssl_context;
-  redisSSLContextError *redis_ssl_error;
+  redisSSLContextError redis_ssl_error;
 
   // Initialise OpenSSL
   redisInitOpenSSL();
 
   // Set up the SSL connection parameters
   redis_ssl_context = redisCreateSSLContext(
-    CHAR(STRING_ELT(CApath, 0)), 
+    CHAR(STRING_ELT(CApath, 0)),
     NULL, /* not providing path to trusted certs */
     CHAR(STRING_ELT(CERTpath, 0)), 
     CHAR(STRING_ELT(KEYpath, 0)), 
     CHAR(STRING_ELT(host, 0)),
     &redis_ssl_error);
 
-  if(redis_ssl_context != REDIS_OK) {
-    redisFree(redis_ssl_context);
+  if(redis_ssl_context == NULL || redis_ssl_error != 0) {
     error("Failed to create SSL context: %s\n",
-      redisSSLContextGetError(redis_ssl_error));
+      (redis_ssl_error != 0) ? 
+        redisSSLContextGetError(redis_ssl_error) : "Unknown error");
   }
 
   // Initiate a connection with redis
@@ -62,12 +62,13 @@ SEXP redux_redis_connect_ssl(SEXP host, SEXP port, SEXP CApath,
 
   // Now we have a connection established, we can negotiate the SSL connection
   if (redisInitiateSSLWithContext(context, redis_ssl_context) != REDIS_OK) {
-        redisFree(context);
-        redisFree(redis_ssl_context);
+        redisFreeSSLContext(redis_ssl_context);
         if (context->err != 0) {
           const char * errstr_ssl = string_duplicate(context->errstr);
-          error("Failed to initialize SSL connection: %s\n", context->errstr);
+          redisFree(context);
+          error("Failed to initialize SSL connection: %s\n", errstr_ssl);
         }
+        redisFree(context);
         error("Failed to initialize SSL connection\n");
   }
   SEXP extPtr = PROTECT(R_MakeExternalPtr(context, host, R_NilValue));

--- a/src/connection.h
+++ b/src/connection.h
@@ -1,6 +1,7 @@
 #include <R.h>
 #include <Rinternals.h>
 #include <hiredis.h>
+#include <hiredis_ssl.h>
 #include <stdbool.h>
 
 SEXP redux_redis_connect(SEXP host, SEXP port);

--- a/src/connection.h
+++ b/src/connection.h
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 
 SEXP redux_redis_connect(SEXP host, SEXP port);
+SEXP redux_redis_connect_ssl(SEXP host, SEXP port, 
+                             SEXP CApath, SEXP certPath, SEXP keyPath);
 SEXP redux_redis_connect_unix(SEXP path);
 
 SEXP redux_redis_command(SEXP extPtr, SEXP cmd);

--- a/src/registration.c
+++ b/src/registration.c
@@ -6,6 +6,7 @@
 
 static const R_CallMethodDef callMethods[] = {
   {"Credux_redis_connect",       (DL_FUNC) &redux_redis_connect,        2},
+  {"Credux_redis_connect_ssl",   (DL_FUNC) &redux_redis_connect_ssl,    5},
   {"Credux_redis_connect_unix",  (DL_FUNC) &redux_redis_connect_unix,   1},
 
   {"Credux_redis_command",       (DL_FUNC) &redux_redis_command,        2},

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,6 +1,6 @@
-if (!file.exists("../windows/hiredis-0.9.2/include/hiredis/hiredis.h")) {
+if (!file.exists("../windows/hiredis-1.0.0/include/hiredis/hiredis.h")) {
   if (getRversion() < "3.3.0") setInternet2()
-  download.file("https://github.com/rwinlib/hiredis/archive/v0.9.2.zip", "lib.zip", quiet = TRUE)
+  download.file("https://github.com/rwinlib/hiredis/archive/v1.0.0.zip", "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
Adds support to redux for making SSL connections to redis. Makes use of SSL support added in [hiredis 1.0.0](https://github.com/redis/hiredis). Addresses #27.

Multi-platform support:
 - **Windows:** Known working in Windows 10 (based on updates included within this PR and #35), using the updated binaries provided in [rwinlib/hiredis](https://github.com/rwinlib/hiredis).
 - **Linux:** Working when built against custom-compiled hiredis-1.0.0 with SSL support, fixes needed for automated build (see below)
 - **MacOS:** Working when built against custom-compiled hiredis-1.0.0 with SSL support, fixes needed for automated build (see below)

Known issues:
 - **Linux:** At present, based on the `configure` script, if a version of hiredis is not found using `pkg-config` or via `INCLUDE_DIR` and `LIB_DIR` being provided to point to a custom compiled version of hiredis, an error is shown with details of the package names to install on common distros. My understanding is that most (all?) distros don't yet have packages for hiredis 1.0.0 and there is no SSL support.
 - **MacOS:** The current [Homebrew formula for hiredis](https://formulae.brew.sh/formula/hiredis) is for v0.14 and again includes no SSL support. If building against a custom compiled version of hiredis 1.0.0 with SSL support, then things work OK on MacOS.

**Question:** @richfitz, @jeroen: How would you like to handle the issue of missing SSL support on standard configurations on Linux/MacOS? For now, should we simply wrap the content of the `redux_redis_connect_ssl` function in [`connection.c`](https://github.com/jcohen02/redux/blob/feature/ssl/src/connection.c) in a pre-processor directive that online includes the content of this function for a Windows build and returns an error saying that the library was not built with SSL support for other platforms? This would at least ensure the library continues to operate as before on Linux/MacOS under a standard build.