### PR TITLE
i40: Support for Redis 6.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ autobrew
 docs/
 doc
 Meta
+*.so
+*.o

--- a/R/redis_api_generated.R
+++ b/R/redis_api_generated.R
@@ -1,19 +1,62 @@
 redis_commands <- function(command) {
   list(
+    ACL_LOAD = function() {
+      command(list("ACL", "LOAD"))
+    },
+    ACL_SAVE = function() {
+      command(list("ACL", "SAVE"))
+    },
+    ACL_LIST = function() {
+      command(list("ACL", "LIST"))
+    },
+    ACL_USERS = function() {
+      command(list("ACL", "USERS"))
+    },
+    ACL_GETUSER = function(username) {
+      assert_scalar2(username)
+      command(list("ACL", "GETUSER", username))
+    },
+    ACL_SETUSER = function(username, rule = NULL) {
+      assert_scalar2(username)
+      command(list("ACL", "SETUSER", username, rule))
+    },
+    ACL_DELUSER = function(username) {
+      command(list("ACL", "DELUSER", username))
+    },
+    ACL_CAT = function(categoryname = NULL) {
+      assert_scalar_or_null2(categoryname)
+      command(list("ACL", "CAT", categoryname))
+    },
+    ACL_GENPASS = function(bits = NULL) {
+      assert_scalar_or_null2(bits)
+      command(list("ACL", "GENPASS", bits))
+    },
+    ACL_WHOAMI = function() {
+      command(list("ACL", "WHOAMI"))
+    },
+    ACL_LOG = function(count_or_RESET = NULL) {
+      assert_scalar_or_null2(count_or_RESET)
+      command(list("ACL", "LOG", count_or_RESET))
+    },
+    ACL_HELP = function() {
+      command(list("ACL", "HELP"))
+    },
     APPEND = function(key, value) {
       assert_scalar2(key)
       assert_scalar2(value)
       command(list("APPEND", key, value))
     },
-    AUTH = function(password) {
+    AUTH = function(password, username = NULL) {
+      assert_scalar_or_null2(username)
       assert_scalar2(password)
-      command(list("AUTH", password))
+      command(list("AUTH", username, password))
     },
     BGREWRITEAOF = function() {
       command(list("BGREWRITEAOF"))
     },
-    BGSAVE = function() {
-      command(list("BGSAVE"))
+    BGSAVE = function(schedule = NULL) {
+      assert_match_value_or_null(schedule, c("SCHEDULE"))
+      command(list("BGSAVE", schedule))
     },
     BITCOUNT = function(key, start = NULL, end = NULL) {
       assert_scalar2(key)
@@ -55,6 +98,14 @@ redis_commands <- function(command) {
       assert_scalar2(timeout)
       command(list("BRPOPLPUSH", source, destination, timeout))
     },
+    BLMOVE = function(source, destination, wherefrom, whereto, timeout) {
+      assert_scalar2(source)
+      assert_scalar2(destination)
+      assert_match_value(wherefrom, c("LEFT", "RIGHT"))
+      assert_match_value(whereto, c("LEFT", "RIGHT"))
+      assert_scalar2(timeout)
+      command(list("BLMOVE", source, destination, wherefrom, whereto, timeout))
+    },
     BZPOPMIN = function(key, timeout) {
       assert_scalar2(timeout)
       command(list("BZPOPMIN", key, timeout))
@@ -63,16 +114,20 @@ redis_commands <- function(command) {
       assert_scalar2(timeout)
       command(list("BZPOPMAX", key, timeout))
     },
+    CLIENT_CACHING = function(mode) {
+      stop("Do not use CLIENT CACHING; not supported with this client")
+    },
     CLIENT_ID = function() {
       command(list("CLIENT", "ID"))
     },
-    CLIENT_KILL = function(ip_port = NULL, ID = NULL, TYPE = NULL, ADDR = NULL, SKIPME = NULL) {
+    CLIENT_KILL = function(ip_port = NULL, ID = NULL, TYPE = NULL, USER = NULL, ADDR = NULL, SKIPME = NULL) {
       assert_scalar_or_null2(ip_port)
       assert_scalar_or_null2(ID)
       assert_match_value_or_null(TYPE, c("normal", "master", "slave", "pubsub"))
+      assert_scalar_or_null2(USER)
       assert_scalar_or_null2(ADDR)
       assert_scalar_or_null2(SKIPME)
-      command(list("CLIENT", "KILL", ip_port, cmd_command("ID", ID, FALSE), cmd_command("TYPE", TYPE, FALSE), cmd_command("ADDR", ADDR, FALSE), cmd_command("SKIPME", SKIPME, FALSE)))
+      command(list("CLIENT", "KILL", ip_port, cmd_command("ID", ID, FALSE), cmd_command("TYPE", TYPE, FALSE), cmd_command("USER", USER, FALSE), cmd_command("ADDR", ADDR, FALSE), cmd_command("SKIPME", SKIPME, FALSE)))
     },
     CLIENT_LIST = function(TYPE = NULL) {
       assert_match_value_or_null(TYPE, c("normal", "master", "replica", "pubsub"))
@@ -81,16 +136,22 @@ redis_commands <- function(command) {
     CLIENT_GETNAME = function() {
       command(list("CLIENT", "GETNAME"))
     },
+    CLIENT_GETREDIR = function() {
+      stop("Do not use CLIENT GETREDIR; not supported with this client")
+    },
     CLIENT_PAUSE = function(timeout) {
       assert_scalar2(timeout)
       command(list("CLIENT", "PAUSE", timeout))
     },
     CLIENT_REPLY = function(reply_mode) {
-      stop("Do not use CLIENT_REPLY; not supported with this client")
+      stop("Do not use CLIENT REPLY; not supported with this client")
     },
     CLIENT_SETNAME = function(connection_name) {
       assert_scalar2(connection_name)
       command(list("CLIENT", "SETNAME", connection_name))
+    },
+    CLIENT_TRACKING = function(status, REDIRECT = NULL, PREFIX = NULL, BCAST = NULL, OPTIN = NULL, OPTOUT = NULL, NOLOOP = NULL) {
+      stop("Do not use CLIENT TRACKING; not supported with this client")
     },
     CLIENT_UNBLOCK = function(client_id, unblock_type = NULL) {
       assert_scalar2(client_id)
@@ -99,6 +160,9 @@ redis_commands <- function(command) {
     },
     CLUSTER_ADDSLOTS = function(slot) {
       command(list("CLUSTER", "ADDSLOTS", slot))
+    },
+    CLUSTER_BUMPEPOCH = function() {
+      command(list("CLUSTER", "BUMPEPOCH"))
     },
     CLUSTER_COUNT_FAILURE_REPORTS = function(node_id) {
       assert_scalar2(node_id)
@@ -114,6 +178,9 @@ redis_commands <- function(command) {
     CLUSTER_FAILOVER = function(options = NULL) {
       assert_match_value_or_null(options, c("FORCE", "TAKEOVER"))
       command(list("CLUSTER", "FAILOVER", options))
+    },
+    CLUSTER_FLUSHSLOTS = function() {
+      command(list("CLUSTER", "FLUSHSLOTS"))
     },
     CLUSTER_FORGET = function(node_id) {
       assert_scalar2(node_id)
@@ -135,6 +202,9 @@ redis_commands <- function(command) {
       assert_scalar2(ip)
       assert_scalar2(port)
       command(list("CLUSTER", "MEET", ip, port))
+    },
+    CLUSTER_MYID = function() {
+      command(list("CLUSTER", "MYID"))
     },
     CLUSTER_NODES = function() {
       command(list("CLUSTER", "NODES"))
@@ -282,7 +352,7 @@ redis_commands <- function(command) {
       assert_scalar2(key)
       assert_scalar2(member1)
       assert_scalar2(member2)
-      assert_scalar_or_null2(unit)
+      assert_match_value_or_null(unit, c("m", "km", "ft", "mi"))
       command(list("GEODIST", key, member1, member2, unit))
     },
     GEORADIUS = function(key, longitude, latitude, radius, unit, withcoord = NULL, withdist = NULL, withhash = NULL, COUNT = NULL, order = NULL, STORE = NULL, STOREDIST = NULL) {
@@ -338,6 +408,9 @@ redis_commands <- function(command) {
       assert_scalar2(key)
       command(list("HDEL", key, field))
     },
+    HELLO = function(protover, AUTH = NULL, SETNAME = NULL) {
+      stop("Do not use HELLO; RESP3 not supported with this client")
+    },
     HEXISTS = function(key, field) {
       assert_scalar2(key)
       assert_scalar2(field)
@@ -383,9 +456,8 @@ redis_commands <- function(command) {
     },
     HSET = function(key, field, value) {
       assert_scalar2(key)
-      assert_scalar2(field)
-      assert_scalar2(value)
-      command(list("HSET", key, field, value))
+      field <- cmd_interleave(field, value)
+      command(list("HSET", key, field))
     },
     HSETNX = function(key, field, value) {
       assert_scalar2(key)
@@ -420,6 +492,12 @@ redis_commands <- function(command) {
       assert_scalar_or_null2(section)
       command(list("INFO", section))
     },
+    LOLWUT = function(VERSION = NULL) {
+      assert_scalar_or_null2(VERSION)
+      res <- command(list("LOLWUT", cmd_command("VERSION", VERSION, FALSE)))
+      message(trimws(res))
+      invisible(res)
+    },
     KEYS = function(pattern) {
       assert_scalar2(pattern)
       command(list("KEYS", pattern))
@@ -432,12 +510,12 @@ redis_commands <- function(command) {
       assert_scalar2(index)
       command(list("LINDEX", key, index))
     },
-    LINSERT = function(key, where, pivot, value) {
+    LINSERT = function(key, where, pivot, element) {
       assert_scalar2(key)
       assert_match_value(where, c("BEFORE", "AFTER"))
       assert_scalar2(pivot)
-      assert_scalar2(value)
-      command(list("LINSERT", key, where, pivot, value))
+      assert_scalar2(element)
+      command(list("LINSERT", key, where, pivot, element))
     },
     LLEN = function(key) {
       assert_scalar2(key)
@@ -447,14 +525,21 @@ redis_commands <- function(command) {
       assert_scalar2(key)
       command(list("LPOP", key))
     },
-    LPUSH = function(key, value) {
+    LPOS = function(key, element, RANK = NULL, COUNT = NULL, MAXLEN = NULL) {
       assert_scalar2(key)
-      command(list("LPUSH", key, value))
+      assert_scalar2(element)
+      assert_scalar_or_null2(RANK)
+      assert_scalar_or_null2(COUNT)
+      assert_scalar_or_null2(MAXLEN)
+      command(list("LPOS", key, element, cmd_command("RANK", RANK, FALSE), cmd_command("COUNT", COUNT, FALSE), cmd_command("MAXLEN", MAXLEN, FALSE)))
     },
-    LPUSHX = function(key, value) {
+    LPUSH = function(key, element) {
       assert_scalar2(key)
-      assert_scalar2(value)
-      command(list("LPUSHX", key, value))
+      command(list("LPUSH", key, element))
+    },
+    LPUSHX = function(key, element) {
+      assert_scalar2(key)
+      command(list("LPUSHX", key, element))
     },
     LRANGE = function(key, start, stop) {
       assert_scalar2(key)
@@ -462,17 +547,17 @@ redis_commands <- function(command) {
       assert_scalar2(stop)
       command(list("LRANGE", key, start, stop))
     },
-    LREM = function(key, count, value) {
+    LREM = function(key, count, element) {
       assert_scalar2(key)
       assert_scalar2(count)
-      assert_scalar2(value)
-      command(list("LREM", key, count, value))
+      assert_scalar2(element)
+      command(list("LREM", key, count, element))
     },
-    LSET = function(key, index, value) {
+    LSET = function(key, index, element) {
       assert_scalar2(key)
       assert_scalar2(index)
-      assert_scalar2(value)
-      command(list("LSET", key, index, value))
+      assert_scalar2(element)
+      command(list("LSET", key, index, element))
     },
     LTRIM = function(key, start, stop) {
       assert_scalar2(key)
@@ -503,7 +588,7 @@ redis_commands <- function(command) {
     MGET = function(key) {
       command(list("MGET", key))
     },
-    MIGRATE = function(host, port, key, destination_db, timeout, copy = NULL, replace = NULL, KEYS = NULL) {
+    MIGRATE = function(host, port, key, destination_db, timeout, copy = NULL, replace = NULL, AUTH = NULL, AUTH2 = NULL, KEYS = NULL) {
       assert_scalar2(host)
       assert_scalar2(port)
       assert_match_value(key, c("key", ""))
@@ -511,7 +596,20 @@ redis_commands <- function(command) {
       assert_scalar2(timeout)
       assert_match_value_or_null(copy, c("COPY"))
       assert_match_value_or_null(replace, c("REPLACE"))
-      command(list("MIGRATE", host, port, key, destination_db, timeout, copy, replace, cmd_command("KEYS", KEYS, TRUE)))
+      assert_scalar_or_null2(AUTH)
+      assert_scalar_or_null2(AUTH2)
+      command(list("MIGRATE", host, port, key, destination_db, timeout, copy, replace, cmd_command("AUTH", AUTH, FALSE), cmd_command("AUTH2", AUTH2, FALSE), cmd_command("KEYS", KEYS, TRUE)))
+    },
+    MODULE_LIST = function() {
+      command(list("MODULE", "LIST"))
+    },
+    MODULE_LOAD = function(path, arg = NULL) {
+      assert_scalar2(path)
+      command(list("MODULE", "LOAD", path, arg))
+    },
+    MODULE_UNLOAD = function(name) {
+      assert_scalar2(name)
+      command(list("MODULE", "UNLOAD", name))
     },
     MONITOR = function() {
       command(list("MONITOR"))
@@ -634,14 +732,20 @@ redis_commands <- function(command) {
       assert_scalar2(destination)
       command(list("RPOPLPUSH", source, destination))
     },
-    RPUSH = function(key, value) {
-      assert_scalar2(key)
-      command(list("RPUSH", key, value))
+    LMOVE = function(source, destination, wherefrom, whereto) {
+      assert_scalar2(source)
+      assert_scalar2(destination)
+      assert_match_value(wherefrom, c("LEFT", "RIGHT"))
+      assert_match_value(whereto, c("LEFT", "RIGHT"))
+      command(list("LMOVE", source, destination, wherefrom, whereto))
     },
-    RPUSHX = function(key, value) {
+    RPUSH = function(key, element) {
       assert_scalar2(key)
-      assert_scalar2(value)
-      command(list("RPUSHX", key, value))
+      command(list("RPUSH", key, element))
+    },
+    RPUSHX = function(key, element) {
+      assert_scalar2(key)
+      command(list("RPUSHX", key, element))
     },
     SADD = function(key, member) {
       assert_scalar2(key)
@@ -682,12 +786,13 @@ redis_commands <- function(command) {
       assert_scalar2(index)
       command(list("SELECT", index))
     },
-    SET = function(key, value, expiration = NULL, condition = NULL) {
+    SET = function(key, value, expiration = NULL, condition = NULL, get = NULL) {
       assert_scalar2(key)
       assert_scalar2(value)
-      assert_match_value_or_null(expiration, c("EX seconds", "PX milliseconds"))
+      assert_match_value_or_null(expiration, c("EX seconds", "PX milliseconds", "KEEPTTL"))
       assert_match_value_or_null(condition, c("NX", "XX"))
-      command(list("SET", key, value, cmd_command("expiration", expiration, FALSE), condition))
+      assert_match_value_or_null(get, c("GET"))
+      command(list("SET", key, value, expiration, condition, get))
     },
     SETBIT = function(key, offset, value) {
       assert_scalar2(key)
@@ -727,6 +832,10 @@ redis_commands <- function(command) {
       assert_scalar2(key)
       assert_scalar2(member)
       command(list("SISMEMBER", key, member))
+    },
+    SMISMEMBER = function(key, member) {
+      assert_scalar2(key)
+      command(list("SMISMEMBER", key, member))
     },
     SLAVEOF = function(host, port) {
       assert_scalar2(host)
@@ -776,6 +885,10 @@ redis_commands <- function(command) {
       assert_scalar2(key)
       command(list("SREM", key, member))
     },
+    STRALGO = function(algorithm, algo_specific_argument) {
+      assert_match_value(algorithm, c("LCS"))
+      command(list("STRALGO", algorithm, algo_specific_argument))
+    },
     STRLEN = function(key) {
       assert_scalar2(key)
       command(list("STRLEN", key))
@@ -790,13 +903,16 @@ redis_commands <- function(command) {
       assert_scalar2(destination)
       command(list("SUNIONSTORE", destination, key))
     },
-    SWAPDB = function(index, index_1) {
-      assert_scalar2(index)
-      assert_scalar2(index_1)
-      command(list("SWAPDB", index, index_1))
+    SWAPDB = function(index1, index2) {
+      assert_scalar2(index1)
+      assert_scalar2(index2)
+      command(list("SWAPDB", index1, index2))
     },
     SYNC = function() {
       command(list("SYNC"))
+    },
+    PSYNC = function(replicationid, offset) {
+      stop("Do not use PSYNC; not supported with this client")
     },
     TIME = function() {
       command(list("TIME"))
@@ -829,13 +945,14 @@ redis_commands <- function(command) {
     WATCH = function(key) {
       command(list("WATCH", key))
     },
-    ZADD = function(key, score, member, condition = NULL, change = NULL, increment = NULL) {
+    ZADD = function(key, score, member, condition = NULL, comparison = NULL, change = NULL, increment = NULL) {
       assert_scalar2(key)
       assert_match_value_or_null(condition, c("NX", "XX"))
+      assert_match_value_or_null(comparison, c("GT", "LT"))
       assert_match_value_or_null(change, c("CH"))
       assert_match_value_or_null(increment, c("INCR"))
       score <- cmd_interleave(score, member)
-      command(list("ZADD", key, condition, change, increment, score))
+      command(list("ZADD", key, condition, comparison, change, increment, score))
     },
     ZCARD = function(key) {
       assert_scalar2(key)
@@ -852,6 +969,12 @@ redis_commands <- function(command) {
       assert_scalar2(increment)
       assert_scalar2(member)
       command(list("ZINCRBY", key, increment, member))
+    },
+    ZINTER = function(numkeys, key, WEIGHTS = NULL, AGGREGATE = NULL, withscores = NULL) {
+      assert_scalar2(numkeys)
+      assert_match_value_or_null(AGGREGATE, c("SUM", "MIN", "MAX"))
+      assert_match_value_or_null(withscores, c("WITHSCORES"))
+      command(list("ZINTER", numkeys, key, cmd_command("WEIGHTS", WEIGHTS, TRUE), cmd_command("AGGREGATE", AGGREGATE, FALSE), withscores))
     },
     ZINTERSTORE = function(destination, numkeys, key, WEIGHTS = NULL, AGGREGATE = NULL) {
       assert_scalar2(destination)
@@ -956,6 +1079,16 @@ redis_commands <- function(command) {
       assert_scalar2(member)
       command(list("ZSCORE", key, member))
     },
+    ZUNION = function(numkeys, key, WEIGHTS = NULL, AGGREGATE = NULL, withscores = NULL) {
+      assert_scalar2(numkeys)
+      assert_match_value_or_null(AGGREGATE, c("SUM", "MIN", "MAX"))
+      assert_match_value_or_null(withscores, c("WITHSCORES"))
+      command(list("ZUNION", numkeys, key, cmd_command("WEIGHTS", WEIGHTS, TRUE), cmd_command("AGGREGATE", AGGREGATE, FALSE), withscores))
+    },
+    ZMSCORE = function(key, member) {
+      assert_scalar2(key)
+      command(list("ZMSCORE", key, member))
+    },
     ZUNIONSTORE = function(destination, numkeys, key, WEIGHTS = NULL, AGGREGATE = NULL) {
       assert_scalar2(destination)
       assert_scalar2(numkeys)
@@ -997,10 +1130,10 @@ redis_commands <- function(command) {
       assert_match_value_or_null(help, c("HELP"))
       command(list("XINFO", cmd_command("CONSUMERS", CONSUMERS, TRUE), cmd_command("GROUPS", GROUPS, FALSE), cmd_command("STREAM", STREAM, FALSE), help))
     },
-    XADD = function(key, ID, field, string) {
+    XADD = function(key, ID, field, value) {
       assert_scalar2(key)
       assert_scalar2(ID)
-      field <- cmd_interleave(field, string)
+      field <- cmd_interleave(field, value)
       command(list("XADD", key, ID, field))
     },
     XTRIM = function(key, strategy, count, approx = NULL) {
@@ -1032,18 +1165,19 @@ redis_commands <- function(command) {
       assert_scalar2(key)
       command(list("XLEN", key))
     },
-    XREAD = function(streams, key, ID, COUNT = NULL, BLOCK = NULL) {
+    XREAD = function(streams, key, id, COUNT = NULL, BLOCK = NULL) {
       assert_scalar_or_null2(COUNT)
       assert_scalar_or_null2(BLOCK)
       assert_match_value(streams, c("STREAMS"))
-      command(list("XREAD", cmd_command("COUNT", COUNT, FALSE), cmd_command("BLOCK", BLOCK, FALSE), streams, key, ID))
+      command(list("XREAD", cmd_command("COUNT", COUNT, FALSE), cmd_command("BLOCK", BLOCK, FALSE), streams, key, id))
     },
-    XGROUP = function(CREATE = NULL, SETID = NULL, DESTROY = NULL, DELCONSUMER = NULL) {
+    XGROUP = function(CREATE = NULL, SETID = NULL, DESTROY = NULL, CREATECONSUMER = NULL, DELCONSUMER = NULL) {
       assert_length_or_null(CREATE, 3L)
       assert_length_or_null(SETID, 3L)
       assert_length_or_null(DESTROY, 2L)
+      assert_length_or_null(CREATECONSUMER, 3L)
       assert_length_or_null(DELCONSUMER, 3L)
-      command(list("XGROUP", cmd_command("CREATE", CREATE, TRUE), cmd_command("SETID", SETID, TRUE), cmd_command("DESTROY", DESTROY, TRUE), cmd_command("DELCONSUMER", DELCONSUMER, TRUE)))
+      command(list("XGROUP", cmd_command("CREATE", CREATE, TRUE), cmd_command("SETID", SETID, TRUE), cmd_command("DESTROY", DESTROY, TRUE), cmd_command("CREATECONSUMER", CREATECONSUMER, TRUE), cmd_command("DELCONSUMER", DELCONSUMER, TRUE)))
     },
     XREADGROUP = function(GROUP, streams, key, ID, COUNT = NULL, BLOCK = NULL, noack = NULL) {
       assert_length(GROUP, 2L)
@@ -1078,9 +1212,41 @@ redis_commands <- function(command) {
       assert_scalar_or_null2(count)
       assert_scalar_or_null2(consumer)
       command(list("XPENDING", key, group, start, end, count, consumer))
+    },
+    LATENCY_DOCTOR = function() {
+      command(list("LATENCY", "DOCTOR"))
+    },
+    LATENCY_GRAPH = function(event) {
+      assert_scalar2(event)
+      command(list("LATENCY", "GRAPH", event))
+    },
+    LATENCY_HISTORY = function(event) {
+      assert_scalar2(event)
+      command(list("LATENCY", "HISTORY", event))
+    },
+    LATENCY_LATEST = function() {
+      command(list("LATENCY", "LATEST"))
+    },
+    LATENCY_RESET = function(event = NULL) {
+      command(list("LATENCY", "RESET", event))
+    },
+    LATENCY_HELP = function() {
+      command(list("LATENCY", "HELP"))
     })
 }
 cmd_since <- numeric_version(c(
+  ACL_CAT = "6.0.0",
+  ACL_DELUSER = "6.0.0",
+  ACL_GENPASS = "6.0.0",
+  ACL_GETUSER = "6.0.0",
+  ACL_HELP = "6.0.0",
+  ACL_LIST = "6.0.0",
+  ACL_LOAD = "6.0.0",
+  ACL_LOG = "6.0.0",
+  ACL_SAVE = "6.0.0",
+  ACL_SETUSER = "6.0.0",
+  ACL_USERS = "6.0.0",
+  ACL_WHOAMI = "6.0.0",
   APPEND = "2.0.0",
   AUTH = "1.0.0",
   BGREWRITEAOF = "1.0.0",
@@ -1089,29 +1255,36 @@ cmd_since <- numeric_version(c(
   BITFIELD = "3.2.0",
   BITOP = "2.6.0",
   BITPOS = "2.8.7",
+  BLMOVE = "6.2.0",
   BLPOP = "2.0.0",
   BRPOP = "2.0.0",
   BRPOPLPUSH = "2.2.0",
   BZPOPMAX = "5.0.0",
   BZPOPMIN = "5.0.0",
+  CLIENT_CACHING = "6.0.0",
   CLIENT_GETNAME = "2.6.9",
+  CLIENT_GETREDIR = "6.0.0",
   CLIENT_ID = "5.0.0",
   CLIENT_KILL = "2.4.0",
   CLIENT_LIST = "2.4.0",
   CLIENT_PAUSE = "2.9.50",
-  CLIENT_REPLY = "3.2",
+  CLIENT_REPLY = "3.2.0",
   CLIENT_SETNAME = "2.6.9",
+  CLIENT_TRACKING = "6.0.0",
   CLIENT_UNBLOCK = "5.0.0",
   CLUSTER_ADDSLOTS = "3.0.0",
+  CLUSTER_BUMPEPOCH = "3.0.0",
   CLUSTER_COUNT_FAILURE_REPORTS = "3.0.0",
   CLUSTER_COUNTKEYSINSLOT = "3.0.0",
   CLUSTER_DELSLOTS = "3.0.0",
   CLUSTER_FAILOVER = "3.0.0",
+  CLUSTER_FLUSHSLOTS = "3.0.0",
   CLUSTER_FORGET = "3.0.0",
   CLUSTER_GETKEYSINSLOT = "3.0.0",
   CLUSTER_INFO = "3.0.0",
   CLUSTER_KEYSLOT = "3.0.0",
   CLUSTER_MEET = "3.0.0",
+  CLUSTER_MYID = "3.0.0",
   CLUSTER_NODES = "3.0.0",
   CLUSTER_REPLICAS = "5.0.0",
   CLUSTER_REPLICATE = "3.0.0",
@@ -1157,6 +1330,7 @@ cmd_since <- numeric_version(c(
   GETRANGE = "2.4.0",
   GETSET = "1.0.0",
   HDEL = "2.0.0",
+  HELLO = "6.0.0",
   HEXISTS = "2.0.0",
   HGET = "2.0.0",
   HGETALL = "2.0.0",
@@ -1177,10 +1351,19 @@ cmd_since <- numeric_version(c(
   INFO = "1.0.0",
   KEYS = "1.0.0",
   LASTSAVE = "1.0.0",
+  LATENCY_DOCTOR = "2.8.13",
+  LATENCY_GRAPH = "2.8.13",
+  LATENCY_HELP = "2.8.13",
+  LATENCY_HISTORY = "2.8.13",
+  LATENCY_LATEST = "2.8.13",
+  LATENCY_RESET = "2.8.13",
   LINDEX = "1.0.0",
   LINSERT = "2.2.0",
   LLEN = "1.0.0",
+  LMOVE = "6.2.0",
+  LOLWUT = "5.0.0",
   LPOP = "1.0.0",
+  LPOS = "6.0.6",
   LPUSH = "1.0.0",
   LPUSHX = "2.2.0",
   LRANGE = "1.0.0",
@@ -1195,6 +1378,9 @@ cmd_since <- numeric_version(c(
   MEMORY_USAGE = "4.0.0",
   MGET = "1.0.0",
   MIGRATE = "2.6.0",
+  MODULE_LIST = "4.0.0",
+  MODULE_LOAD = "4.0.0",
+  MODULE_UNLOAD = "4.0.0",
   MONITOR = "1.0.0",
   MOVE = "1.0.0",
   MSET = "1.0.1",
@@ -1210,6 +1396,7 @@ cmd_since <- numeric_version(c(
   PING = "1.0.0",
   PSETEX = "2.6.0",
   PSUBSCRIBE = "2.0.0",
+  PSYNC = "2.8.0",
   PTTL = "2.6.0",
   PUBLISH = "2.0.0",
   PUBSUB = "2.8.0",
@@ -1251,12 +1438,14 @@ cmd_since <- numeric_version(c(
   SLAVEOF = "1.0.0",
   SLOWLOG = "2.2.12",
   SMEMBERS = "1.0.0",
+  SMISMEMBER = "6.2.0",
   SMOVE = "1.0.0",
   SORT = "1.0.0",
   SPOP = "1.0.0",
   SRANDMEMBER = "1.0.0",
   SREM = "1.0.0",
   SSCAN = "2.8.0",
+  STRALGO = "6.0.0",
   STRLEN = "2.2.0",
   SUBSCRIBE = "2.0.0",
   SUNION = "1.0.0",
@@ -1289,8 +1478,10 @@ cmd_since <- numeric_version(c(
   ZCARD = "1.2.0",
   ZCOUNT = "2.0.0",
   ZINCRBY = "1.2.0",
+  ZINTER = "6.2.0",
   ZINTERSTORE = "2.0.0",
   ZLEXCOUNT = "2.8.9",
+  ZMSCORE = "6.2.0",
   ZPOPMAX = "5.0.0",
   ZPOPMIN = "5.0.0",
   ZRANGE = "1.2.0",
@@ -1307,4 +1498,5 @@ cmd_since <- numeric_version(c(
   ZREVRANK = "2.0.0",
   ZSCAN = "2.8.0",
   ZSCORE = "1.2.0",
+  ZUNION = "6.2.0",
   ZUNIONSTORE = "2.0.0"))

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -1,5 +1,5 @@
 assert_match_value <- function(x, choices, name = deparse(substitute(x))) {
-  assert_scalar_character(x)
+  assert_scalar_character(x, name = name)
   if (!(x %in% choices)) {
     stop(sprintf("%s must be one of %s", name,
                  paste(dQuote(choices), collapse = ", ")))

--- a/extra/generate_fun.R
+++ b/extra/generate_fun.R
@@ -68,7 +68,9 @@ hiredis_cmd <- function(x, standalone = FALSE) {
   is_grouped <- lengths(args$name) > 1L
 
   if (any(is_command)) {
-    if(is.null(args$name)) args$name = args$command
+    if (is.null(args$name)) {
+      args$name <- args$command
+    }
     
     j <- is_command & !(is_grouped & is_multiple)
     args$name_orig <- args$name
@@ -78,7 +80,7 @@ hiredis_cmd <- function(x, standalone = FALSE) {
   }
   
   if (any(duplicated(args$name))) {
-    args$name = make.unique(args$name, sep = "_")
+    stop("Duplicated names")
   }
   
   if (any(args$variadic)) {

--- a/extra/generate_fun.R
+++ b/extra/generate_fun.R
@@ -121,9 +121,10 @@ hiredis_cmd <- function(x, standalone = FALSE) {
     stop("duplicate names")
   }
   ## The colon here is for CLIENT KILL
-  args$name <- gsub("[-:]", "_", args$name)
+  ## The space here is for count or RESET
+  args$name <- gsub("[-: ]", "_", args$name)
   if (any(grepl("[^A-Za-z0-9._]", args$name))) {
-    stop("invalid names")
+    stop("invalid names: ", paste(args$name, collapse = ", "))
   }
 
   is_optional <- is_field("optional", args)

--- a/extra/generate_fun.R
+++ b/extra/generate_fun.R
@@ -68,13 +68,19 @@ hiredis_cmd <- function(x, standalone = FALSE) {
   is_grouped <- lengths(args$name) > 1L
 
   if (any(is_command)) {
+    if(is.null(args$name)) args$name = args$command
+    
     j <- is_command & !(is_grouped & is_multiple)
     args$name_orig <- args$name
     args$command_length <- viapply(args$name, length)
     args$name[j] <- args$command[j]
     is_grouped <- viapply(args$name, length) > 1L
   }
-
+  
+  if (any(duplicated(args$name))) {
+    args$name = make.unique(args$name, sep = "_")
+  }
+  
   if (any(args$variadic)) {
     args$command_length[args$variadic] <- 2
   }

--- a/tests/testthat/helper-common.R
+++ b/tests/testthat/helper-common.R
@@ -53,10 +53,6 @@ rand_str <- function(len = 8, prefix = "") {
          paste(sample(c(LETTERS, letters, 0:9), len), collapse = ""))
 }
 
-vcapply <- function(X, FUN, ...) {
-  vapply(X, FUN, character(1), ...)
-}
-
 sys_setenv <- function(...) {
   vars <- names(list(...))
   prev <- vapply(vars, Sys.getenv, "", NA_character_)

--- a/tests/testthat/test-zzz-commands-acl.R
+++ b/tests/testthat/test-zzz-commands-acl.R
@@ -1,0 +1,129 @@
+context("commands - acl")
+
+test_that("ACL CAT", {
+  expect_equal(redis_cmds$ACL_CAT(), list("ACL", "CAT", NULL))
+  expect_equal(redis_cmds$ACL_CAT("read"), list("ACL", "CAT", "read"))
+})
+
+test_that("ACL CAT (server)", {
+  skip_if_cmd_unsupported("ACL_CAT")
+  con <- test_hiredis_connection()
+  res <- con$ACL_CAT()
+  expect_type(res, "list")
+  expect_true("dangerous" %in% unlist(res))
+  res <- con$ACL_CAT("dangerous")
+  expect_type(res, "list")
+  expect_true("acl" %in% unlist(res))
+})
+
+
+test_that("ACL DEL", {
+  expect_equal(redis_cmds$ACL_DELUSER("x"), list("ACL", "DELUSER", "x"))
+  expect_equal(redis_cmds$ACL_DELUSER(c("x", "y")),
+               list("ACL", "DELUSER", c("x", "y")))
+})
+
+
+test_that("ACL GENPASS", {
+  expect_equal(redis_cmds$ACL_GENPASS(), list("ACL", "GENPASS", NULL))
+  expect_equal(redis_cmds$ACL_GENPASS(256), list("ACL", "GENPASS", 256))
+})
+
+
+test_that("ACL GENPASS (server)", {
+  skip_if_cmd_unsupported("ACL_GENPASS")
+  con <- test_hiredis_connection()
+  expect_match(con$ACL_GENPASS(), "^[[:xdigit:]]{64}$")
+  expect_match(con$ACL_GENPASS(128), "^[[:xdigit:]]{32}$")
+})
+
+
+test_that("ACL GETUSER", {
+  expect_equal(redis_cmds$ACL_GETUSER("default"),
+               list("ACL", "GETUSER", "default"))
+})
+
+
+test_that("ACL GETUSER (server)", {
+  skip_if_cmd_unsupported("ACL_GETUSER")
+  con <- test_hiredis_connection()
+  res <- con$ACL_GETUSER("default")
+  expect_type(res, "list")
+})
+
+
+test_that("ACL HELP", {
+  expect_equal(redis_cmds$ACL_HELP(), list("ACL", "HELP"))
+})
+
+
+## This is dubiously helpful in its current form
+test_that("ACL HELP (server)", {
+  skip_if_cmd_unsupported("ACL_HELP")
+  con <- test_hiredis_connection()
+  res <- con$ACL_HELP()
+  expect_type(res, "list")
+})
+
+
+test_that("ACL LIST", {
+  expect_equal(redis_cmds$ACL_LIST(), list("ACL", "LIST"))
+})
+
+
+test_that("ACL LIST", {
+  skip_if_cmd_unsupported("ACL_LIST")
+  con <- test_hiredis_connection()
+  res <- con$ACL_LIST()
+  expect_match(unlist(res), "^user default", all = FALSE)
+})
+
+
+test_that("ACL LOAD", {
+  expect_equal(redis_cmds$ACL_LOAD(), list("ACL", "LOAD"))
+})
+
+
+test_that("ACL LOG", {
+  expect_equal(redis_cmds$ACL_LOG(), list("ACL", "LOG", NULL))
+  expect_equal(redis_cmds$ACL_LOG("RESET"), list("ACL", "LOG", "RESET"))
+  expect_equal(redis_cmds$ACL_LOG(1), list("ACL", "LOG", 1))
+})
+
+
+test_that("ACL SAVE", {
+  expect_equal(redis_cmds$ACL_SAVE(), list("ACL", "SAVE"))
+})
+
+
+test_that("ACL SETUSER", {
+  expect_equal(redis_cmds$ACL_SETUSER("me"), list("ACL", "SETUSER", "me", NULL))
+  expect_equal(redis_cmds$ACL_SETUSER("me", c("reset", "rule", "value")),
+               list("ACL", "SETUSER", "me", c("reset", "rule", "value")))
+})
+
+
+
+test_that("ACL USERS", {
+  expect_equal(redis_cmds$ACL_USERS(), list("ACL", "USERS"))
+})
+
+
+test_that("ACL USERS (server)", {
+  skip_if_cmd_unsupported("ACL_USERS")
+  con <- test_hiredis_connection()
+  res <- con$ACL_USERS()
+  expect_true("default" %in% unlist(res))
+})
+
+
+test_that("ACL WHOAMI", {
+  expect_equal(redis_cmds$ACL_WHOAMI(), list("ACL", "WHOAMI"))
+})
+
+
+test_that("ACL WHOAMI (server)", {
+  skip_if_cmd_unsupported("ACL_WHOAMI")
+  con <- test_hiredis_connection()
+  expect_equal(con$ACL_WHOAMI(), "default")
+})

--- a/tests/testthat/test-zzz-commands-cluster.R
+++ b/tests/testthat/test-zzz-commands-cluster.R
@@ -5,6 +5,11 @@ test_that("CLUSTER ADDSLOTS", {
                list("CLUSTER", "ADDSLOTS", 1:3))
 })
 
+test_that("CLUSTER BUMPEPOCH", {
+  expect_equal(redis_cmds$CLUSTER_BUMPEPOCH(),
+               list("CLUSTER", "BUMPEPOCH"))
+})
+
 test_that("CLUSTER COUNT-FAILURE-REPORTS", {
   expect_equal(redis_cmds$CLUSTER_COUNT_FAILURE_REPORTS("id"),
                list("CLUSTER", "COUNT-FAILURE-REPORTS", "id"))
@@ -27,6 +32,11 @@ test_that("CLUSTER FAILOVER", {
                list("CLUSTER", "FAILOVER", "FORCE"))
   expect_equal(redis_cmds$CLUSTER_FAILOVER("TAKEOVER"),
                list("CLUSTER", "FAILOVER", "TAKEOVER"))
+})
+
+test_that("CLUSTER FLUSHSLOTS", {
+  expect_equal(redis_cmds$CLUSTER_FLUSHSLOTS(),
+               list("CLUSTER", "FLUSHSLOTS"))
 })
 
 test_that("CLUSTER FORGET", {
@@ -54,9 +64,19 @@ test_that("CLUSTER MEET", {
                list("CLUSTER", "MEET", "B-ip", "B-port"))
 })
 
+test_that("CLUSTER MYID", {
+  expect_equal(redis_cmds$CLUSTER_MYID(),
+               list("CLUSTER", "MYID"))
+})
+
 test_that("CLUSTER NODES", {
   expect_equal(redis_cmds$CLUSTER_NODES(),
                list("CLUSTER", "NODES"))
+})
+
+test_that("CLUSTER REPLICAS", {
+  expect_equal(redis_cmds$CLUSTER_REPLICAS("id"),
+               list("CLUSTER", "REPLICAS", "id"))
 })
 
 test_that("CLUSTER REPLICATE", {

--- a/tests/testthat/test-zzz-commands-connection.R
+++ b/tests/testthat/test-zzz-commands-connection.R
@@ -2,7 +2,8 @@ context("commands - connection")
 
 test_that("AUTH", {
   pw <- rand_str()
-  expect_equal(redis_cmds$AUTH(pw), list("AUTH", pw))
+  expect_equal(redis_cmds$AUTH(pw), list("AUTH", NULL, pw))
+  expect_equal(redis_cmds$AUTH(pw, "user"), list("AUTH", "user", pw))
 })
 
 test_that("ECHO", {

--- a/tests/testthat/test-zzz-commands-generic.R
+++ b/tests/testthat/test-zzz-commands-generic.R
@@ -287,7 +287,8 @@ test_that("MIGRATE", {
   timeout <- 5000
   keys <- letters
   expect_equal(redis_cmds$MIGRATE(ip, port, "", db, timeout,  KEYS = letters),
-               list("MIGRATE", ip, port, "", db, timeout, NULL, NULL,
+               list("MIGRATE", ip, port, "", db, timeout,
+                    NULL, NULL, NULL, NULL,
                     list("KEYS", keys)))
 })
 

--- a/tests/testthat/test-zzz-commands-geo.R
+++ b/tests/testthat/test-zzz-commands-geo.R
@@ -29,8 +29,8 @@ test_that("GEOADD:run", {
 test_that("GEOHASH:prep", {
   key <- rand_str()
   nms <- c("Palermo", "Catania")
-  list(redis_cmds$GEOHASH(key, nms),
-       list("GEOHASH", key, nms))
+  expect_equal(redis_cmds$GEOHASH(key, nms),
+               list("GEOHASH", key, nms))
 })
 
 test_that("GEOHASH:run", {

--- a/tests/testthat/test-zzz-commands-server.R
+++ b/tests/testthat/test-zzz-commands-server.R
@@ -4,14 +4,16 @@ context("commands - server")
 test_that("CLIENT KILL", {
   expect_equal(redis_cmds$CLIENT_KILL(ID = "12", SKIPME = "yes"),
                list("CLIENT", "KILL", NULL, list("ID", "12"),
-                    NULL, NULL, list("SKIPME", "yes")))
+                    NULL, NULL, NULL, list("SKIPME", "yes")))
   expect_equal(redis_cmds$CLIENT_KILL(ID = "11", SKIPME = "no"),
                list("CLIENT", "KILL", NULL, list("ID", "11"),
-                    NULL, NULL, list("SKIPME", "no")))
+                    NULL, NULL, NULL, list("SKIPME", "no")))
 })
 
 test_that("CLIENT LIST", {
-  expect_equal(redis_cmds$CLIENT_LIST(), list("CLIENT", "LIST"))
+  expect_equal(redis_cmds$CLIENT_LIST(), list("CLIENT", "LIST", NULL))
+  expect_equal(redis_cmds$CLIENT_LIST("normal"),
+               list("CLIENT", "LIST", list("TYPE", "normal")))
 })
 
 test_that("CLIENT GETNAME", {
@@ -32,6 +34,40 @@ test_that("CLIENT SETNAME", {
   name <- rand_str()
   expect_equal(redis_cmds$CLIENT_SETNAME(name),
                list("CLIENT", "SETNAME", name))
+})
+
+## New client commands since version 5-6
+test_that("CLIENT ID", {
+  expect_equal(redis_cmds$CLIENT_ID(), list("CLIENT", "ID"))
+})
+
+test_that("CLIENT ID (server)", {
+  skip_if_cmd_unsupported("CLIENT_ID")
+  con <- test_hiredis_connection()
+  res <- con$CLIENT_ID()
+  expect_type(res, "integer")
+})
+
+test_that("CLIENT CACHING", {
+  expect_error(redis_cmds$CLIENT_CACHING("YES"),
+               "Do not use CLIENT CACHING; not supported with this client")
+})
+
+test_that("CLIENT GETREDIR", {
+  expect_error(redis_cmds$CLIENT_GETREDIR(),
+               "Do not use CLIENT GETREDIR; not supported with this client")
+})
+
+test_that("CLIENT TRACKING", {
+  expect_error(redis_cmds$CLIENT_TRACKING("ON"),
+               "Do not use CLIENT TRACKING; not supported with this client")
+})
+
+test_that("CLIENT UNBLOCK", {
+  expect_equal(redis_cmds$CLIENT_UNBLOCK(1L),
+               list("CLIENT", "UNBLOCK", 1L, NULL))
+  expect_equal(redis_cmds$CLIENT_UNBLOCK(1L, "ERROR"),
+               list("CLIENT", "UNBLOCK", 1L, "ERROR"))
 })
 
 test_that("COMMAND", {
@@ -66,11 +102,17 @@ test_that("DBSIZE", {
 })
 
 test_that("FLUSHALL", {
-  expect_equal(redis_cmds$FLUSHALL(), list("FLUSHALL"))
+  expect_equal(redis_cmds$FLUSHALL(), list("FLUSHALL", NULL))
+  expect_equal(redis_cmds$FLUSHALL("ASYNC"), list("FLUSHALL", "ASYNC"))
+  expect_error(redis_cmds$FLUSHALL("SYNC"),
+               "async must be one of")
 })
 
 test_that("FLUSHDB", {
-  expect_equal(redis_cmds$FLUSHDB(), list("FLUSHDB"))
+  expect_equal(redis_cmds$FLUSHDB(), list("FLUSHDB", NULL))
+  expect_equal(redis_cmds$FLUSHDB("ASYNC"), list("FLUSHDB", "ASYNC"))
+  expect_error(redis_cmds$FLUSHDB("SYNC"),
+               "async must be one of")
 })
 
 test_that("INFO", {
@@ -102,7 +144,8 @@ test_that("BGREWRITEAOF", {
 })
 
 test_that("BGSAVE", {
-  expect_equal(redis_cmds$BGSAVE(), list("BGSAVE"))
+  expect_equal(redis_cmds$BGSAVE(), list("BGSAVE", NULL))
+  expect_equal(redis_cmds$BGSAVE("SCHEDULE"), list("BGSAVE", "SCHEDULE"))
 })
 
 test_that("CONFIG REWRITE", {
@@ -150,6 +193,110 @@ test_that("SLAVEOF", {
   expect_equal(redis_cmds$SLAVEOF("NO", "ONE"), list("SLAVEOF", "NO", "ONE"))
 })
 
+test_that("REPLICAOF", {
+  expect_equal(redis_cmds$REPLICAOF("NO", "ONE"),
+               list("REPLICAOF", "NO", "ONE"))
+})
+
 test_that("SYNC", {
   expect_equal(redis_cmds$SYNC(), list("SYNC"))
+})
+
+test_that("LOLWUT", {
+  expect_equal(redis_cmds$LOLWUT(), list("LOLWUT", NULL))
+  expect_equal(redis_cmds$LOLWUT(5), list("LOLWUT", list("VERSION", 5)))
+})
+
+test_that("LOLWUT (server)", {
+  skip_if_cmd_unsupported("LOLWUT")
+  con <- test_hiredis_connection()
+  expect_message(con$LOLWUT())
+})
+
+test_that("MEMORY DOCTOR", {
+  expect_equal(redis_cmds$MEMORY_DOCTOR(), list("MEMORY", "DOCTOR"))
+})
+
+test_that("MEMORY HELP", {
+  expect_equal(redis_cmds$MEMORY_HELP(), list("MEMORY", "HELP"))
+})
+
+test_that("MEMORY MALLOC_STATS", {
+  expect_equal(redis_cmds$MEMORY_MALLOC_STATS(),
+               list("MEMORY", "MALLOC-STATS"))
+})
+
+test_that("MEMORY PURGE", {
+  expect_equal(redis_cmds$MEMORY_PURGE(), list("MEMORY", "PURGE"))
+})
+
+test_that("MEMORY PURGE", {
+  expect_equal(redis_cmds$MEMORY_PURGE(), list("MEMORY", "PURGE"))
+})
+
+test_that("MEMORY STATS", {
+  expect_equal(redis_cmds$MEMORY_STATS(), list("MEMORY", "STATS"))
+})
+
+test_that("MEMORY USAGE", {
+  expect_equal(redis_cmds$MEMORY_USAGE(""), list("MEMORY", "USAGE", "", NULL))
+  expect_equal(redis_cmds$MEMORY_USAGE("key"),
+               list("MEMORY", "USAGE", "key", NULL))
+})
+
+test_that("MODULE LIST", {
+  expect_equal(redis_cmds$MODULE_LIST(), list("MODULE", "LIST"))
+})
+
+test_that("MODULE LOAD", {
+  expect_equal(redis_cmds$MODULE_LOAD("path"),
+               list("MODULE", "LOAD", "path", NULL))
+})
+
+test_that("MODULE UNLOAD", {
+  expect_equal(redis_cmds$MODULE_UNLOAD("name"),
+               list("MODULE", "UNLOAD", "name"))
+})
+
+test_that("SWAP DB", {
+  expect_equal(redis_cmds$SWAPDB(0, 1),
+               list("SWAPDB", 0, 1))
+})
+
+test_that("LATENCY_DOCTOR", {
+  expect_equal(redis_cmds$LATENCY_DOCTOR(), list("LATENCY", "DOCTOR"))
+})
+
+
+test_that("LATENCY_GRAPH", {
+  expect_equal(redis_cmds$LATENCY_GRAPH("command"),
+               list("LATENCY", "GRAPH", "command"))
+})
+
+test_that("LATENCY_HISTORY", {
+  expect_equal(redis_cmds$LATENCY_HISTORY("command"),
+               list("LATENCY", "HISTORY", "command"))
+})
+
+test_that("LATENCY_LATEST", {
+  expect_equal(redis_cmds$LATENCY_LATEST(), list("LATENCY", "LATEST"))
+})
+
+test_that("LATENCY_RESET", {
+  expect_equal(redis_cmds$LATENCY_RESET("command"),
+               list("LATENCY", "RESET", "command"))
+})
+
+test_that("LATENCY_HELP", {
+  expect_equal(redis_cmds$LATENCY_HELP(), list("LATENCY", "HELP"))
+})
+
+test_that("HELLO", {
+  expect_error(redis_cmds$HELLO(),
+               "Do not use HELLO; RESP3 not supported with this client")
+})
+
+test_that("PSYNC", {
+  expect_error(redis_cmds$PSYNC(),
+               "Do not use PSYNC; not supported with this client")
 })

--- a/tests/testthat/test-zzz-commands-set.R
+++ b/tests/testthat/test-zzz-commands-set.R
@@ -225,3 +225,19 @@ test_that("SUNIONSTORE", {
 })
 
 ## SSCAN in the scan tests
+
+test_that("SMISMEMBER (mock)", {
+  expect_equal(redis_cmds$SMISMEMBER("key", c("one", "two")),
+               list("SMISMEMBER", "key", c("one", "two")))
+})
+
+test_that("SMISMEMBER", {
+  skip_if_cmd_unsupported("SMISMEMBER")
+  con <- test_hiredis_connection()
+  key <- rand_str()
+  on.exit(con$DEL(key))
+
+  con$SADD(key, "one")
+  con$SADD(key, "two")
+  expect_equal(con$SMISMEMBER(key, c("one", "notamember")), list(1, 0))
+})

--- a/tests/testthat/test-zzz-commands-sorted-set.R
+++ b/tests/testthat/test-zzz-commands-sorted-set.R
@@ -328,3 +328,115 @@ test_that("ZINTERSTORE", {
   expect_equal(con$ZRANGE(key3, 0, -1, "WITHSCORES"),
                list("one", "5", "three", "9", "two", "10"))
 })
+
+test_that("ZINTER (mock)", {
+  expect_equal(
+    redis_cmds$ZINTER(2, c("key1", "key2")),
+    list("ZINTER", 2, c("key1", "key2"), NULL, NULL, NULL))
+  expect_equal(
+    redis_cmds$ZINTER(2, c("key1", "key2"), withscores = "WITHSCORES"),
+    list("ZINTER", 2, c("key1", "key2"), NULL, NULL, "WITHSCORES"))
+})
+
+test_that("ZINTER", {
+  skip_if_cmd_unsupported("ZINTER")
+  con <- test_hiredis_connection()
+  key1 <- rand_str()
+  key2 <- rand_str()
+  key3 <- rand_str()
+  on.exit(con$DEL(c(key1, key2, key3)))
+
+  con$ZADD(key1, 1, "one")
+  con$ZADD(key1, 2, "two")
+  con$ZADD(key2, 1, "one")
+  con$ZADD(key2, 2, "two")
+  con$ZADD(key2, 3, "three")
+
+  expect_equal(con$ZINTER(2, c(key1, key2)), list("one", "two"))
+  expect_equal(con$ZINTER(2, c(key1, key2), withscores = "WITHSCORES"),
+               list("one", "2", "two", "4"))
+})
+
+test_that("ZPOPMIN", {
+  skip_if_cmd_unsupported("ZPOPMIN")
+  con <- test_hiredis_connection()
+  key <- rand_str()
+  con$ZADD(key, 1, "one")
+  con$ZADD(key, 2, "two")
+  con$ZADD(key, 3, "three")
+  expect_equal(con$ZPOPMIN(key), list("one", "1"))
+})
+
+test_that("ZPOPMAX", {
+  skip_if_cmd_unsupported("ZPOPMAX")
+  con <- test_hiredis_connection()
+  key <- rand_str()
+  con$ZADD(key, 1, "one")
+  con$ZADD(key, 2, "two")
+  con$ZADD(key, 3, "three")
+  expect_equal(con$ZPOPMAX(key), list("three", "3"))
+})
+
+test_that("ZUNION (mock)", {
+  expect_equal(
+    redis_cmds$ZUNION(2, c("key1", "key2")),
+    list("ZUNION", 2, c("key1", "key2"), NULL, NULL, NULL))
+  expect_equal(
+    redis_cmds$ZUNION(2, c("key1", "key2"), withscores = "WITHSCORES"),
+    list("ZUNION", 2, c("key1", "key2"), NULL, NULL, "WITHSCORES"))
+})
+
+test_that("ZUNION", {
+  skip_if_cmd_unsupported("ZUNION")
+  con <- test_hiredis_connection()
+  key1 <- rand_str()
+  key2 <- rand_str()
+  key3 <- rand_str()
+  on.exit(con$DEL(c(key1, key2, key3)))
+
+  con$ZADD(key1, 1, "one")
+  con$ZADD(key1, 2, "two")
+  con$ZADD(key2, 1, "one")
+  con$ZADD(key2, 2, "two")
+  con$ZADD(key2, 3, "three")
+
+  expect_equal(con$ZUNION(2, c(key1, key2)),
+               list("one", "three", "two"))
+  expect_equal(con$ZUNION(2, c(key1, key2), withscores = "WITHSCORES"),
+               list("one", "2", "three", "3", "two", "4"))
+})
+
+test_that("ZMSCORE (mock)", {
+  expect_equal(redis_cmds$ZMSCORE("key", c("one", "two", "nofield")),
+               list("ZMSCORE", "key", c("one", "two", "nofield")))
+})
+
+test_that("ZMSCORE", {
+  skip_if_cmd_unsupported("ZMSCORE")
+  con <- test_hiredis_connection()
+  key <- rand_str()
+  con$ZADD(key, 1, "one")
+  con$ZADD(key, 2, "two")
+  expect_equal(con$ZMSCORE(key, c("one", "two", "nofield")),
+               list("1", "2", NULL))
+})
+
+test_that("BZPOPMIN", {
+  skip_if_cmd_unsupported("ZMSCORE")
+  con <- test_hiredis_connection()
+  key1 <- rand_str()
+  key2 <- rand_str()
+  con$ZADD(key1, c(0, 1, 2), c("a", "b", "c"))
+  expect_equal(con$BZPOPMIN(c(key1, key2), 10),
+               list(key1, "a", "0"))
+})
+
+test_that("BZPOPMAX", {
+  skip_if_cmd_unsupported("ZMSCORE")
+  con <- test_hiredis_connection()
+  key1 <- rand_str()
+  key2 <- rand_str()
+  con$ZADD(key1, c(0, 1, 2), c("a", "b", "c"))
+  expect_equal(con$BZPOPMAX(c(key1, key2), 10),
+               list(key1, "c", "2"))
+})

--- a/tests/testthat/test-zzz-commands-stream.R
+++ b/tests/testthat/test-zzz-commands-stream.R
@@ -1,0 +1,111 @@
+context("commands (stream)")
+
+test_that("XADD", {
+  skip_if_cmd_unsupported("XADD")
+  con <- test_hiredis_connection()
+  stream <- rand_str()
+  id1 <- con$XADD(stream, "*", c("name", "surname"), c("Sara", "OConnor"))
+  id2 <- con$XADD(stream, "*", paste0("field", 1:3), paste0("value", 1:3))
+  expect_equal(con$XLEN(stream), 2)
+  expect_equal(
+    con$XRANGE(stream, "-", "+"),
+    list(
+      list(
+        id1,
+        list("name", "Sara", "surname", "OConnor")),
+      list(
+        id2,
+        list("field1", "value1", "field2", "value2", "field3", "value3"))))
+})
+
+
+test_that("XDEL", {
+  skip_if_cmd_unsupported("XDEL")
+  con <- test_hiredis_connection()
+  stream <- rand_str()
+  id1 <- con$XADD(stream, "*", "a", 1)
+  id2 <- con$XADD(stream, "*", "b", 2)
+  id3 <- con$XADD(stream, "*", "c", 3)
+  con$XDEL(stream, id2)
+  expect_equal(
+    con$XRANGE(stream, "-", "+"),
+    list(list(id1, list("a", "1")),
+         list(id3, list("c", "3"))))
+})
+
+
+test_that("XLEN", {
+  skip_if_cmd_unsupported("XLEN")
+  con <- test_hiredis_connection()
+  stream <- rand_str()
+  id1 <- con$XADD(stream, "*", "a", 1)
+  id2 <- con$XADD(stream, "*", "b", 2)
+  id3 <- con$XADD(stream, "*", "c", 3)
+  expect_equal(con$XLEN(stream), 3)
+})
+
+
+## Adopted from the docs examples
+test_that("XACK", {
+  expect_equal(redis_cmds$XACK("mystream", "mygroup", "1526569495631-0"),
+               list("XACK", "mystream", "mygroup", "1526569495631-0"))
+})
+
+test_that("XCLAIM", {
+  expect_equal(
+    redis_cmds$XCLAIM("mystream", "mygroup", "Alice", 3600000,
+                      "1526569498055-0"),
+    list("XCLAIM", "mystream", "mygroup", "Alice", 3600000, "1526569498055-0",
+         NULL, NULL, NULL, NULL, NULL))
+})
+
+## This lot feels like it might want splitting apart? XGROUP_CREATE etc?
+test_that("XGROUP", {
+  expect_equal(
+    redis_cmds$XGROUP(CREATE = c("mystream", "consumer-group-name", "$")),
+    list("XGROUP", list("CREATE", c("mystream", "consumer-group-name", "$")),
+         NULL, NULL, NULL, NULL))
+  expect_equal(
+    redis_cmds$XGROUP(CREATE = c("mystream", "consumer-group-name", 0)),
+    list("XGROUP", list("CREATE", c("mystream", "consumer-group-name", 0)),
+         NULL, NULL, NULL, NULL))
+  ## TODO: MKSTREAM not supported for CREATE
+
+  expect_equal(
+    redis_cmds$XGROUP(DESTROY = c("mystream", "consumer-group-name")),
+    list("XGROUP", NULL, NULL,
+         list("DESTROY", c("mystream", "consumer-group-name")), NULL, NULL))
+
+  expect_equal(
+    redis_cmds$XGROUP(CREATECONSUMER = c("mystream", "consumer-group-name",
+                                         "myconsumer123")),
+    list("XGROUP", NULL, NULL, NULL,
+         list("CREATECONSUMER", c("mystream", "consumer-group-name",
+                                  "myconsumer123")), NULL))
+
+  expect_equal(
+    redis_cmds$XGROUP(DELCONSUMER = c("mystream", "consumer-group-name",
+                                      "myconsumer123")),
+    list("XGROUP", NULL, NULL, NULL, NULL,
+         list("DELCONSUMER", c("mystream",  "consumer-group-name",
+                               "myconsumer123"))))
+
+  expect_equal(
+    redis_cmds$XGROUP(SETID = c("mystream", "consumer-group-name", 0)),
+    list("XGROUP", NULL,
+         list("SETID", c("mystream", "consumer-group-name", 0)),
+         NULL, NULL, NULL))
+})
+
+
+test_that("XINFO", {
+  expect_equal(
+    redis_cmds$XINFO(STREAM = "mystream"),
+    list("XINFO", NULL, NULL, list("STREAM", "mystream"), NULL))
+  expect_equal(
+    redis_cmds$XINFO(GROUPS = "mystream"),
+    list("XINFO", NULL, list("STREAM", "mystream"), NULL, NULL))
+  expect_equal(
+    redis_cmds$XINFO(CONSUMERS = c("mystream", "mygroup")),
+    list("XINFO", list("STREAM", "mystream", "mygroup"), NULL, NULL, NULL))
+})

--- a/tests/testthat/test-zzz-commands-string.R
+++ b/tests/testthat/test-zzz-commands-string.R
@@ -312,3 +312,17 @@ test_that("STRLEN", {
   expect_equal(con$STRLEN(key), 11)
   expect_equal(con$STRLEN("nonexisting"), 0)
 })
+
+test_that("STRALGO (mock)", {
+  expect_equal(
+    redis_cmds$STRALGO("LCS", c("STRINGS", "ohmytext", "mynewtext")),
+    list("STRALGO", "LCS", c("STRINGS", "ohmytext", "mynewtext")))
+})
+
+test_that("STRALGO", {
+  skip_if_cmd_unsupported("STRALGO")
+  con <- test_hiredis_connection()
+  expect_equal(
+    con$STRALGO("LCS", c("STRINGS", "ohmytext", "mynewtext")),
+    "mytext")
+})


### PR DESCRIPTION
Adds support for new commands added through to Redis 6.2.0, incorporating changes in #28, fixing failing tests and adding tests for the new functions.

The interface to the stream (`X*`) functions I am not immediately happy with, as things like `XREADGROUP` I am not sure are properly supported yet, and commands like `XGROUP` really feel like they should be split into subcommands. It might be easiest to fold this in for now and then fix, but to do this properly I probably will have to either understand the streaming interface or get input from someone who has used it (@dseynaev perhaps?).

Fixes #40 
