### PR TITLE
Small tweaks for new autobrew

### DIFF
--- a/configure
+++ b/configure
@@ -32,13 +32,13 @@ elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   if [ $(command -v brew) ]; then
     BREWDIR=$(brew --prefix)
+    PKG_CFLAGS="-I$BREWDIR/include/hiredis -D_FILE_OFFSET_BITS=64"
+    PKG_LIBS="-L$BREWDIR/lib $PKG_LIBS"    
   else
-    curl -sfL "https://jeroen.github.io/autobrew/$PKG_BREW_NAME" > autobrew
+    curl -sfL "https://autobrew.github.io/scripts/hiredis" > autobrew
     source autobrew
     rm autobrew
   fi
-  PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include/hiredis -D_FILE_OFFSET_BITS=64"
-  PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
 fi
 
 # For debugging


### PR DESCRIPTION
I have made some changes to the autobrew scripts to make it faster and support ARM64. It is now recommended to let the script set the appropriate PKG_CFLAGS and PKG_LIBS for you.