### PR TITLE
Experimental conversion control

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: redux
 Title: R Bindings to 'hiredis'
-Version: 1.1.4
+Version: 1.1.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com"))
 Description: A 'hiredis' wrapper that includes support for

--- a/R/connection.R
+++ b/R/connection.R
@@ -72,8 +72,8 @@ redis_connection <- function(config = redis_config()) {
         invisible()
       },
 
-      command = function(cmd) {
-        redis_command(ptr, cmd)
+      command = function(cmd, as = NULL) {
+        redis_command(ptr, cmd, as)
       },
 
       pipeline = function(cmds) {

--- a/R/redis.R
+++ b/R/redis.R
@@ -25,8 +25,8 @@ redis_connect_unix <- function(path, timeout = NULL) {
   .Call(Credux_redis_connect_unix, path, as.integer(timeout))
 }
 
-redis_command <- function(ptr, command) {
-  .Call(Credux_redis_command, ptr, command)
+redis_command <- function(ptr, command, as = NULL) {
+  .Call(Credux_redis_command, ptr, command, as)
 }
 
 redis_pipeline <- function(ptr, list) {

--- a/src/connection.c
+++ b/src/connection.c
@@ -54,8 +54,10 @@ SEXP redux_redis_connect_unix(SEXP r_path, SEXP r_timeout) {
   return extPtr;
 }
 
-SEXP redux_redis_command(SEXP extPtr, SEXP cmd) {
+SEXP redux_redis_command(SEXP extPtr, SEXP cmd, SEXP r_as) {
   redisContext *context = redis_get_context(extPtr, true);
+
+  reply_string_as as = r_reply_string_as(r_as);
 
   cmd = PROTECT(redis_check_command(cmd));
   const char **argv = NULL;
@@ -63,7 +65,7 @@ SEXP redux_redis_command(SEXP extPtr, SEXP cmd) {
   const size_t argc = sexp_to_redis(cmd, &argv, &argvlen);
 
   redisReply *reply = redisCommandArgv(context, argc, argv, argvlen);
-  SEXP ret = PROTECT(redis_reply_to_sexp(reply, true));
+  SEXP ret = PROTECT(redis_reply_to_sexp(reply, true, as));
   freeReplyObject(reply);
   UNPROTECT(2);
   return ret;
@@ -94,7 +96,7 @@ SEXP redux_redis_pipeline(SEXP extPtr, SEXP list) {
   SEXP ret = PROTECT(allocVector(VECSXP, nc));
   for (size_t i = 0; i < nc; ++i) {
     redisGetReply(context, (void*)&reply);
-    SET_VECTOR_ELT(ret, i, redis_reply_to_sexp(reply, false));
+    SET_VECTOR_ELT(ret, i, redis_reply_to_sexp(reply, false, AS_AUTO));
     freeReplyObject(reply);
   }
   UNPROTECT(2);

--- a/src/connection.h
+++ b/src/connection.h
@@ -6,7 +6,7 @@
 SEXP redux_redis_connect(SEXP host, SEXP port, SEXP timeout);
 SEXP redux_redis_connect_unix(SEXP path, SEXP timeout);
 
-SEXP redux_redis_command(SEXP extPtr, SEXP cmd);
+SEXP redux_redis_command(SEXP extPtr, SEXP cmd, SEXP r_as);
 
 SEXP redux_redis_pipeline(SEXP extPtr, SEXP list);
 

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -3,13 +3,21 @@
 #include <hiredis.h>
 #include <stdbool.h>
 
+typedef enum {
+  AS_AUTO,
+  AS_RAW
+} reply_string_as;
+
+reply_string_as r_reply_string_as(SEXP as);
+
 /* whole reply */
-SEXP redis_reply_to_sexp(redisReply* reply, bool error_throw);
+SEXP redis_reply_to_sexp(redisReply* reply, bool error_throw,
+                         reply_string_as as);
 
 /* possible bits of a reply */
-SEXP raw_string_to_sexp(const char* s, size_t len);
+SEXP raw_string_to_sexp(const char* s, size_t len, reply_string_as as);
 SEXP status_to_sexp(const char* s);
-SEXP array_to_sexp(redisReply* reply, bool error_throw);
+SEXP array_to_sexp(redisReply* reply, bool error_throw, reply_string_as as);
 SEXP reply_error(redisReply* reply, bool error_throw);
 
 /* detection */

--- a/src/registration.c
+++ b/src/registration.c
@@ -11,7 +11,7 @@ static const R_CallMethodDef callMethods[] = {
   {"Credux_redis_connect",       (DL_FUNC) &redux_redis_connect,        3},
   {"Credux_redis_connect_unix",  (DL_FUNC) &redux_redis_connect_unix,   2},
 
-  {"Credux_redis_command",       (DL_FUNC) &redux_redis_command,        2},
+  {"Credux_redis_command",       (DL_FUNC) &redux_redis_command,        3},
 
   {"Credux_redis_pipeline",      (DL_FUNC) &redux_redis_pipeline,       2},
 

--- a/src/subscribe.c
+++ b/src/subscribe.c
@@ -8,7 +8,7 @@ SEXP redux_redis_subscribe(SEXP extPtr, SEXP channel, SEXP pattern,
   SET_VECTOR_ELT(cmd, 0, mkString(p ? "PSUBSCRIBE" : "SUBSCRIBE"));
   SET_VECTOR_ELT(cmd, 1, channel);
   cmd = PROTECT(redis_check_command(cmd));
-  SEXP ret = PROTECT(redux_redis_command(extPtr, cmd));
+  SEXP ret = PROTECT(redux_redis_command(extPtr, cmd, R_NilValue));
 
   redux_redis_subscribe_loop(redis_get_context(extPtr, true),
                              p, callback, envir);
@@ -39,7 +39,7 @@ void redux_redis_subscribe_loop(redisContext* context, int pattern,
   while (keep_going) {
     R_CheckUserInterrupt();
     redisGetReply(context, (void*)&reply);
-    SEXP x = PROTECT(redis_reply_to_sexp(reply, false));
+    SEXP x = PROTECT(redis_reply_to_sexp(reply, false, AS_AUTO));
     setAttrib(x, R_NamesSymbol, nms);
     SETCADR(call, x);
     freeReplyObject(reply);
@@ -90,7 +90,7 @@ SEXP redux_redis_unsubscribe(SEXP extPtr, SEXP channel, SEXP pattern) {
     n_discarded++;
     redisGetReply(context, (void*)&reply);
   }
-  SEXP ret = PROTECT(redis_reply_to_sexp(reply, true));
+  SEXP ret = PROTECT(redis_reply_to_sexp(reply, true, AS_AUTO));
   freeReplyObject(reply);
   if (n_discarded > 0) {
     SEXP key = PROTECT(mkString("n_discarded"));

--- a/tests/testthat/test-redis.R
+++ b/tests/testthat/test-redis.R
@@ -176,3 +176,30 @@ test_that("pointer commands are safe", {
   expect_error(redis_command(ptr_null, "PING"),
                "Context is not connected")
 })
+
+
+test_that("can get raw strings back if asked", {
+  skip_if_no_redis()
+  ptr <- redis_connect_tcp(REDIS_HOST, REDIS_PORT)
+  key <- rand_str()
+  value <- rand_str()
+
+  expect_equal(redis_command(ptr, list("SET", key, value)),
+               redis_status("OK"))
+
+  expect_equal(redis_command(ptr, list("GET", key), "auto"),
+               value)
+  expect_equal(redis_command(ptr, list("GET", key), "raw"),
+               charToRaw(value))
+
+  expect_error(redis_command(ptr, list("GET", key), "other"),
+               "Invalid option for 'as'")
+  expect_error(redis_command(ptr, list("GET", key), TRUE),
+               "Invalid option for 'as'")
+  expect_error(redis_command(ptr, list("GET", key), letters),
+               "Invalid option for 'as'")
+  expect_error(redis_command(ptr, list("GET", key), character()),
+               "Invalid option for 'as'")
+
+  expect_equal(redis_command(ptr, c("DEL", key)), 1L)
+})


### PR DESCRIPTION
This PR adds an experimental and subject-to-change interface to the **low level** redis commands to control how string conversion happens, to address #60. You can run any redis command by using the lower level interface:

```r
con <- hiredis()
con$command(list("PING"))
#> [Redis: PONG]
```

So we can already set data this way:

```r
con$command(list("SET", "key", "value")) # same as con$SET("key", "value"))
#> [Redis: OK]
```

and get data this way:

```r
con$command(list("GET", "key")) # same as con$GET("key")
#> [1] "value"
```

The new feature added in this PR is a 3rd argument to `$command`, `as`, which is a string taking values `auto` (the current behaviour) or `raw` (the default `NULL` is equivalent to `auto`).  In action:

```r
con$command(list("GET", "key"), "raw")
#> [1] 76 61 6c 75 65
```
